### PR TITLE
feat(index): export interfaces

### DIFF
--- a/src/TestScheduler.ts
+++ b/src/TestScheduler.ts
@@ -8,7 +8,7 @@ import { TestMessage } from 'rxjs/testing/TestMessage';
 import { isArray } from 'rxjs/util/isArray';
 import { ArgumentOutOfRangeError } from 'rxjs/util/ArgumentOutOfRangeError';
 
-import { VirtualTestScheduler, SchedulerOptions } from './VirtualTestScheduler';
+import { VirtualTestScheduler, SchedulerStartOptions } from './VirtualTestScheduler';
 import { next, error, complete } from './TestMessageValue';
 import { VirtualObserver, BaseVirtualObserver } from './VirtualObserver';
 import { VirtualPromise, BaseVirtualPromise } from './VirtualPromise';
@@ -28,7 +28,7 @@ export class TestScheduler extends VirtualTimeScheduler implements VirtualTestSc
     return actions && actions.length > 0 ? actions[0] : null;
   }
 
-  private setupOptions(options: SchedulerOptions): SchedulerOptions {
+  private setupOptions(options: SchedulerStartOptions): SchedulerStartOptions {
     const ret = options;
     if (!options.created) {
       ret.created = 100;
@@ -139,7 +139,7 @@ export class TestScheduler extends VirtualTimeScheduler implements VirtualTestSc
   }
 
   public startScheduler<T>(observableFactory: () => Observable<T>,
-                           options: SchedulerOptions = {}): VirtualObserver {
+                           options: SchedulerStartOptions = {}): VirtualObserver {
     const schedulerOptions = this.setupOptions(options);
     const { created, subscribed, unsubscribed } = schedulerOptions;
     const observer = this.createObserver();

--- a/src/VirtualTestScheduler.ts
+++ b/src/VirtualTestScheduler.ts
@@ -6,7 +6,7 @@ import { VirtualTimeScheduler } from 'rxjs/scheduler/VirtualTimeScheduler';
 import { VirtualObserver } from './VirtualObserver';
 import { VirtualPromise } from './VirtualPromise';
 
-export interface SchedulerOptions {
+export interface SchedulerStartOptions {
   created?: number;
   subscribed?: number;
   unsubscribed?: number;
@@ -29,6 +29,6 @@ export interface VirtualTestScheduler extends VirtualTimeScheduler {
   scheduleAbsolute<T>(work: (state?: T) => void, dueFrame?: number, state?: T): Subscription;
   scheduleRelative<T>(work: (state?: T) => void, byFrame?: number, state?: T): Subscription;
 
-  startScheduler<T>(observableFactory: () => Observable<T>, options?: SchedulerOptions): VirtualObserver;
+  startScheduler<T>(observableFactory: () => Observable<T>, options?: SchedulerStartOptions): VirtualObserver;
   stop(): void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export { TestScheduler } from './TestScheduler';
+export { VirtualTestScheduler, SchedulerStartOptions } from './VirtualTestScheduler';
+export { VirtualObserver } from './VirtualObserver';
+export { VirtualPromise } from './VirtualPromise';
 export { next, error, complete, subscribe } from './TestMessageValue';


### PR DESCRIPTION
This PR exports public interfaces to `index`, also rename `SchedulerOptions` to `SchedulerStartOptions` for clarity.
