### PR TITLE
fix(BaseVirtualPromise): add finally method to support typescript@2.7…

### DIFF
--- a/src/VirtualPromise.ts
+++ b/src/VirtualPromise.ts
@@ -81,4 +81,8 @@ export class BaseVirtualPromise implements VirtualPromise {
   public catch(_onrejected?: (reason: any) => void): Promise<any> {
     throw new Error('not implemented');
   }
+
+  public finally(_onfinally?: (() => void) | undefined | null): Promise<any> {
+    throw new Error('not implemented');
+  }
 }


### PR DESCRIPTION
… esnext

Currently if you are compiling with `lib: [..., 'esnext']` then you get a compiler error because the new version of the Promise interface has a `finally` method.

Thanks for your work on this module, it has saved us a *lot* of time converting tests.

Let me know if you want anything changed.